### PR TITLE
Fix npm publish workflow not found error

### DIFF
--- a/.github/workflows/CI-CD.yaml
+++ b/.github/workflows/CI-CD.yaml
@@ -26,6 +26,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - run: yarn install --frozen-lockfile
+
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Install dependencies in the `publish` job to resolve `npm-run-all` not found error during `npm publish`.

The `publish` job was failing because its `prepare` script, which runs `yarn run css`, depended on `npm-run-all`. However, dependencies were not installed in the `publish` job, leading to `npm-run-all` being unavailable. Adding `setup-node` and `yarn install` ensures all required dependencies are present before publishing.

---
<a href="https://cursor.com/background-agent?bcId=bc-10377813-5410-4c7c-b08d-51f7214d9302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-10377813-5410-4c7c-b08d-51f7214d9302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

