### PR TITLE
ci: Dependabot monthly + group minor/patch

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,8 +2,11 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "dependencies"
       - "github-actions"
@@ -13,8 +16,11 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "dependencies"
       - "npm"


### PR DESCRIPTION
Reduce Dependabot churn & Actions cost: version updates monthly instead of weekly/daily, and minor+patch grouped into a single PR per ecosystem (majors stay individual so they get attention). Security updates are unaffected (they remain immediate).
